### PR TITLE
Force install of setuptools ==49.6.0

### DIFF
--- a/requirements/private.txt
+++ b/requirements/private.txt
@@ -28,5 +28,5 @@
 fluent-logger==0.9.6
 python-json-logger==0.1.11
 django-debug-toolbar==2.2
-setuptools!=50.0
+setuptools==49.6.0
 django-redis==4.12.1


### PR DESCRIPTION
LMS is throwing Requirement.parse('setuptools>=40.3.0')

bors r+