### PR TITLE
Added Merge Queue integration to the workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Docker Image CI
 
 on:
+  merge_group:
   push:
     branches:
       - eol-release/**
@@ -58,3 +59,12 @@ jobs:
     with:
       code: ${{ needs.variables.outputs.code }}
     secrets: inherit
+
+  MQ-ok:
+    name: Merge-Queue-OK
+    needs: [variables, build, webhook]
+    if: github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI succeeded
+        run: exit 0


### PR DESCRIPTION

**-  A new condition has been added to trigger the workflow when multiple branches are merged in a merge group.**
**- A confirmation step has been added to ensure that the integration and Docker image building have been successful. It simply ends the workflow with an exit code of 0.**
**- In the branch protection rules, specifically for eol-release/koa and openuchile-release/koa, they were configured to require merge queue using the 'merge commit' merge method and to only merge pull requests that do not fail.**

In summary, this workflow will execute when multiple branches are merged in a merge group or when changes are made to release branches (eol-release/** and openuchile-release/) affecting the files 'Dockerfile', 'requirements/*.txt', and 'themes/'.
