### PR TITLE
Add eol progress tab app

### DIFF
--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,2 +1,3 @@
 -e git+https://github.com/eol-uchile/eol_completion@8188c385a678fb94ed2d7f51591a348e51815666#egg=eol_completion
+-e git+https://github.com/eol-uchile/eol_progress_tab@698177942488d4bc3c3b931887e6fef0b94473aa#egg=eol_progress_tab
 -e git+https://github.com/eol-uchile/eol_welcome_mail@d45ed6908eac47bc615c5206572ecdea4d86adc5#egg=welcome-mail


### PR DESCRIPTION
Configurations needed to be applied https://github.com/eol-uchile/eol_progress_tab/blob/master/readme.md

### Configurations
LMS/CMS Django Admin:

/admin/site_configuration/siteconfiguration/
`"EOL_PROGRESS_TAB_ENABLED":true`

No other changes needed according to https://github.com/eol-uchile/eol-edx/pull/159/commits/d8a4b11139e7e8da6edd2b7f1f4c372415e03f43

We need this app in order to get the `grade_cutoff` parameter of a course grading policy through API REST. 
See `https://<lms-url>/courses/<course_id>/eol_progress_tab/course_info`

This parameter was added to grades API in a later commit to edx-platform https://github.com/openedx/edx-platform/commit/a44091e7ec1686e5ead440b38f4970e2063009e6. 