### PR TITLE
fix: removes setuptools dependency

### DIFF
--- a/requirements/python_packages.txt
+++ b/requirements/python_packages.txt
@@ -2,4 +2,3 @@ django-debug-toolbar==2.2.1
 django-redis==4.12.1
 fluent-logger==0.9.6
 python-json-logger==0.1.11
-setuptools==65.5.1


### PR DESCRIPTION
Replaces #836.

Even when the vulnerability is critical, [Ubuntu](https://ubuntu.com/security/CVE-2024-6345) has not fixed the focal version. When that has happened, the fix should come through the edx-platform base image build.

Our addition of packages in the requirements file was due to an already resolved bug https://github.com/eol-uchile/edx-staging/commit/1a25859eb44c3bb1493af1621fdb01ec0a22d2e2, so I think their addition is now useless.