### PR TITLE
build: fix translation error and delete unnecessary empty spaces

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -6,4 +6,4 @@
 -e git+https://github.com/eol-uchile/eol_survey@ab8506723ca972bf9ecb6afd1b4fed3f4cf32501#egg=eol_survey
 -e git+https://github.com/eol-uchile/eol_vimeo@cf918de25456ac716a3c596d44bf0a0cf0564d33#egg=eol_vimeo
 -e git+https://github.com/open-uchile/edx-proctoring@3815d8852fc7059848444fbe401a5c08f89a9aac#egg=edx-proctoring
--e git+https://github.com/open-uchile/eol_contact_form@385965aa1203872ca2ac359e9a3419e879a050d5#egg=eol_contact_form
+-e git+https://github.com/open-uchile/eol_contact_form@6a5e9abece013d8e62a217287a40ce2cd894cf03#egg=eol_contact_form


### PR DESCRIPTION
Se corrige el error de traducción que provocaba la caída del envió de mail en la segunda opción, se quitan también las mayúsculas