### PR TITLE
build: add tag 1.0.0 version to eol_report_certificate

### DIFF
--- a/requirements/reports.txt
+++ b/requirements/reports.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/cmmedu/cmmedu-seguimiento@v1.0.4#egg=cmmedu_seguimiento
 -e git+https://github.com/eol-uchile/eol_grade_ucursos@9974d9d43b4df564a4bdd03fe3205d816c48e5be#egg=gradeucursos
 -e git+https://github.com/eol-uchile/eol_report_analytics@0.0.1#egg=eol_report_analytics
--e git+https://github.com/eol-uchile/eol_report_certificate@a5fdc08eac85e5bd2f12abc98de7d3d62b4e874e#egg=eolreportcertificate
+-e git+https://github.com/eol-uchile/eol_report_certificate@1.0.0#egg=eolreportcertificate
 -e git+https://github.com/eol-uchile/eol_xblock_completion@0.0.3#egg=xblockcompletion


### PR DESCRIPTION
Se actualizo el script test.sh para incluir la generación de cobertura de los test, seguido de una modernización del workflow de integración continua relacionado con los tests. Posteriormente, se refactorizó el código eliminando imports innecesarios y organizando las importaciones en orden alfabético. Se añadieron varias pruebas para mejorar la cobertura, incluyendo casos con course_id incorrectos para las funciones validate_course e is_instructor_or_staff. Luego, se actualizaron los documentos con instrucciones más claras para correr los tests y se añadió una insignia de cobertura. Finalmente, se ajustó la configuración del proyecto para cambiar la metainformación.