### PR TITLE
build: adds tag to eol_instructor in version 0.0.1

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -3,7 +3,7 @@
 -e git+https://github.com/eol-uchile/edx-userdata@0.0.2#egg=edxuserdata
 -e git+https://github.com/eol-uchile/eol_contact_form@c59e764eee1c8bcae8fb25011a78b2353d14aa63#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock
--e git+https://github.com/eol-uchile/eol_instructor@45f9e2f3e5bbf646fd1d16413b082e179d408f04#egg=eol_instructor
+-e git+https://github.com/eol-uchile/eol_instructor@0.0.1#egg=eol_instructor
 -e git+https://github.com/eol-uchile/eol_jump_to@bdbb1fca8ae0e0e7e8d6c38641975942ea9f154e#egg=eol_jump_to
 -e git+https://github.com/eol-uchile/eol_survey@3e46e6ff83f9de1720130e62f452e925a1d9ea4d#egg=eol_survey
 -e git+https://github.com/eol-uchile/eol_vimeo@1.0.0#egg=eol_vimeo


### PR DESCRIPTION
Se agrega al tag 0.0.1 a eol_instructor, se crea el tag en el mismo commit  que estaba en master que es el mas reciente 