### PR TITLE
build: add tag 0.0.1 to eol_welcome_mail

### DIFF
--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -2,4 +2,4 @@
 -e git+https://github.com/eol-uchile/eol_course_email@33cb39a4eee6f3126efb3a1d5b64b3ad798e8c60#egg=eol_course_email
 -e git+https://github.com/eol-uchile/eol_feedback@d293244b53bb50951c9d37106a342bc106c119a5#egg=eol_feedback
 -e git+https://github.com/eol-uchile/eol_progress_tab@698177942488d4bc3c3b931887e6fef0b94473aa#egg=eol_progress_tab
--e git+https://github.com/eol-uchile/eol_welcome_mail@6c5195dbcbdcb9bfc8e619fd221ac5b806194287#egg=welcome_mail
+-e git+https://github.com/eol-uchile/eol_welcome_mail@0.0.1#egg=welcome_mail


### PR DESCRIPTION
Se agrega el tag 0.0.1 a eol:welcome_mail, dentro de los cambios trae la modernización del test.sh y la eliminación de importaciones no usadas
