### PR TITLE
build: add tag 0.0.1 to eol_welcome_mail to open

### DIFF
--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,4 +1,4 @@
 -e git+https://github.com/eol-uchile/eol_completion@8188c385a678fb94ed2d7f51591a348e51815666#egg=eol_completion
 -e git+https://github.com/eol-uchile/eol_course_email@cfcca8a18389f64a1383f686a684c585019d16f1#egg=eol_course_email
 -e git+https://github.com/eol-uchile/eol_progress_tab@698177942488d4bc3c3b931887e6fef0b94473aa#egg=eol_progress_tab
--e git+https://github.com/eol-uchile/eol_welcome_mail@d45ed6908eac47bc615c5206572ecdea4d86adc5#egg=welcome-mail
+-e git+https://github.com/eol-uchile/eol_welcome_mail@0.0.1#egg=welcome-mail


### PR DESCRIPTION
Se agrega el tag 0.0.1 a eol_welcome_mail, dentro de los cambios trae la modernización del test.sh y la eliminación de importaciones no usadas