### PR TITLE
Cata ilabaca/add tag to ubcpi to open

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -9,5 +9,5 @@
 -e git+https://github.com/eol-uchile/eol_list_grade@1.0.0#egg=eollistgrade-xblock
 -e git+https://github.com/eol-uchile/eol_xblock_discussion@1.0.0#egg=eoldiscussion-xblock
 -e git+https://github.com/eol-uchile/eol-zoom-xblock@1.0.0#egg=eolzoom-xblock
--e git+https://github.com/eol-uchile/ubcpi@ae4bac403c89fd6c6525cedb7171a66e3aefca4c#egg=ubcpi-xblock
+-e git+https://github.com/eol-uchile/ubcpi@1.0.0#egg=ubcpi-xblock
 -e git+https://github.com/eol-uchile/pdfXBlock@v0.5.1#egg=pdf-xblock


### PR DESCRIPTION
Se agrega el tag 1.0.0 para orden de código manteniendo el hash del commit que se encuentra en producción