### PR TITLE
ci: use GitHub App token in webhook dispatch

### DIFF
--- a/.github/workflows/webhook.yml
+++ b/.github/workflows/webhook.yml
@@ -6,9 +6,6 @@ on:
       code:
         required: true
         type: string
-    secrets:
-      WEBHOOK_SECRET:
-        required: true
   repository_dispatch:
     types: [debug-webhook]
 
@@ -17,12 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.code || github.event.client_payload.debug
     steps:
+      - name: Create GitHub App Token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.EOLITO_BOT_APP_ID }}
+          private-key: ${{ secrets.EOLITO_BOT_PRIVATE_KEY }}
+
       - name: Trigger edx-kustomize repository workflow
         run: |
           if [[ "${{ inputs.code }}" = "eol" || "${{ github.event.client_payload.debug }}" = "eol" ]]
           then
-            curl --fail-with-body -X POST -H "Authorization: Bearer ${{ secrets.WEBHOOK_SECRET }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-kustomize/dispatches --data '{"event_type": "update-images-v2", "client_payload": {"flavour": "staging"}}'
+            curl --fail-with-body -X POST -H "Authorization: Bearer ${{ steps.app_token.outputs.token }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-kustomize/dispatches --data '{"event_type": "update-images-v2", "client_payload": {"flavour": "staging"}}'
           elif [[ "${{ inputs.code }}" = "ou" || "${{ github.event.client_payload.debug }}" = "ou" ]]
           then
-            curl --fail-with-body -X POST -H "Authorization: Bearer ${{ secrets.WEBHOOK_SECRET }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-kustomize/dispatches --data '{"event_type": "update-images-v2", "client_payload": {"flavour": "ou-staging"}}'
+            curl --fail-with-body -X POST -H "Authorization: Bearer ${{ steps.app_token.outputs.token }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-kustomize/dispatches --data '{"event_type": "update-images-v2", "client_payload": {"flavour": "ou-staging"}}'
           fi


### PR DESCRIPTION
- Remove any requirement for WEBHOOK_SECRET—we no longer need a personal access token.
- Insert step Create GitHub App Token using `actions/create-github-app-token@v2 `