### PR TITLE
ci: Add GitHub App authentication parameters to webhook workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,4 +64,6 @@ jobs:
     uses: ./.github/workflows/webhook.yml
     with:
       code: ${{ needs.variables.outputs.code }}
-    secrets: inherit
+      app_id: ${{ vars.EOLITO_BOT_APP_ID }}
+    secrets:
+      private_key: ${{ secrets.EOLITO_BOT_PRIVATE_KEY }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -48,4 +48,6 @@ jobs:
     uses: ./.github/workflows/webhook.yml
     with:
       code: ${{ github.event.client_payload.code }}
-    secrets: inherit
+      app_id: ${{ vars.EOLITO_BOT_APP_ID }}
+    secrets:
+      private_key: ${{ secrets.EOLITO_BOT_PRIVATE_KEY }}

--- a/.github/workflows/webhook.yml
+++ b/.github/workflows/webhook.yml
@@ -6,6 +6,12 @@ on:
       code:
         required: true
         type: string
+      app_id:
+        required: true
+        type: string
+    secrets:
+      private_key:
+        required: true
   repository_dispatch:
     types: [debug-webhook]
 


### PR DESCRIPTION
- Added `app_id` and `private_key` parameters to webhook workflow.
- Updated `docker.yml` and `images.yml` to pass app_id and private_key when calling webhook workflow.
