### PR TITLE
build: adds tag to edx-search

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/eol-uchile/course_classification@1.0.0#egg=course_classification
--e git+https://github.com/eol-uchile/edx-search@726d991728f78efe3f98d3a71ac4600d46a125ea#egg=edx-search
+-e git+https://github.com/eol-uchile/edx-search@1.4.1+eol1.0.0#egg=edx-search
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock
 -e git+https://github.com/eol-uchile/eol_sso_login@0.1.1#egg=eol_sso_login
 -e git+https://github.com/eol-uchile/eol_survey@1.0.0#egg=eol_survey


### PR DESCRIPTION
Se agrega tag a edx-search para orden del codigo, se cambia la rama default, se agrega un nuevo url, api y view de eol para reemplazar al actual. Manteniendo los cambios de agregar un nuevo estado de "próximamente" y  el filtro correspondiente.