### PR TITLE
ci: add GH App auth to WF docker, images & webhook; update git sign

### DIFF
--- a/.github/workflows/diagram.yml
+++ b/.github/workflows/diagram.yml
@@ -76,8 +76,8 @@ jobs:
 
     - name: Configure Git
       run: |
-        git config user.name ${{ github.actor }}
-        git config user.email ${{ github.actor }}@users.noreply.github.com
+        git config user.name "eolito[bot]"
+        git config user.email "217098583+eolito[bot]@users.noreply.github.com"
 
     - name: Commit UML Images
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,4 +65,6 @@ jobs:
     uses: ./.github/workflows/webhook.yml
     with:
       code: ${{ needs.variables.outputs.code }}
-    secrets: inherit
+      app_id: ${{ vars.EOLITO_BOT_APP_ID }}
+    secrets:
+      private_key: ${{ secrets.EOLITO_BOT_PRIVATE_KEY }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -48,4 +48,6 @@ jobs:
     uses: ./.github/workflows/webhook.yml
     with:
       code: ${{ github.event.client_payload.code }}
-    secrets: inherit
+      app_id: ${{ vars.EOLITO_BOT_APP_ID }}
+    secrets:
+      private_key: ${{ secrets.EOLITO_BOT_PRIVATE_KEY }}

--- a/.github/workflows/webhook.yml
+++ b/.github/workflows/webhook.yml
@@ -6,6 +6,12 @@ on:
       code:
         required: true
         type: string
+      app_id:
+        required: true
+        type: string
+    secrets:
+      private_key:
+        required: true
   repository_dispatch:
     types: [debug-webhook]
 
@@ -18,8 +24,8 @@ jobs:
         id: app_token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.EOLITO_BOT_APP_ID }}
-          private-key: ${{ secrets.EOLITO_BOT_PRIVATE_KEY }}
+          app-id: ${{ inputs.app_id || vars.EOLITO_BOT_APP_ID }}
+          private-key: ${{ secrets.private_key || secrets.EOLITO_BOT_PRIVATE_KEY }}
           owner: eol-uchile
           repositories: edx-kustomize
 


### PR DESCRIPTION
- Updated `webhook.yml`, `docker.yml` and `images.yml` to use GitHub App authentication.
- Updated git `user.email` & `user.name` in `diagram.yml` to sign with GH App info. [Guide thread](https://github.com/orgs/community/discussions/26560?utm_source=chatgpt.com).