### PR TITLE
Cata ilabaca/add tag 1.1.0 to course clasiffication and remove edx search

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,5 +1,4 @@
--e git+https://github.com/eol-uchile/course_classification@1.0.0#egg=course_classification
--e git+https://github.com/eol-uchile/edx-search@1.4.1+eol1.0.0#egg=edx-search
+-e git+https://github.com/eol-uchile/course_classification@1.1.0#egg=course_classification
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock
 -e git+https://github.com/eol-uchile/eol_sso_login@0.1.1#egg=eol_sso_login
 -e git+https://github.com/eol-uchile/eol_survey@1.0.0#egg=eol_survey


### PR DESCRIPTION
Se agrega el nuevo tag de course_classification, donde se agrega una api que reemplaza a la búsqueda para el explorador de cursos antes realizado por edx-search, se agrega una vista también para el mismo fin. Se elimina el repositorio de search, pues la funcionalidad que cumplia ahora esta en course_classification. Se actualiza el tema de open, para que pueda tener el formato necesario para recibir los cursos.