### PR TITLE
build: fix restriction python>-3.11 for edx-username-changer in pypi.org

### DIFF
--- a/requirements/python_packages.txt
+++ b/requirements/python_packages.txt
@@ -1,5 +1,5 @@
 django-debug-toolbar==2.2.1
 django-redis==4.12.1
-edx-username-changer==0.3.2
+-e git+https://github.com/mitodl/edx-username-changer.git@main#egg=edx-username-changer
 fluent-logger==0.9.6
 python-json-logger==0.1.11


### PR DESCRIPTION
En https://pypi.org/project/edx-username-changer/0.3.2/#edx_username_changer-0.3.2-py3-none-any.whl (hace 4 horas de este pr) subieron de nuevo el paquete (sin cambiar la versión) donde incluyeron un refactor en el que agregaron la restricción de funcionar sólo con python >= 3.11, y nuestras imágenes usan python 3.8. Ver https://github.com/mitodl/open-edx-plugins/pull/544/commits/4cfaeada0ce2856319464ee77f30d2358f9761c1.

Esto está generando falla en la generación de nuestras imágenes. Ver #1018 y https://github.com/eol-uchile/edx-openuchile/pull/149.