### PR TITLE
build: fix restriction python>-3.11 for edx-username-changer in pypi.org

### DIFF
--- a/requirements/python_packages.txt
+++ b/requirements/python_packages.txt
@@ -1,4 +1,4 @@
 django-redis==4.12.1
-edx-username-changer==0.3.2
+-e git+https://github.com/mitodl/edx-username-changer.git@main#egg=edx-username-changer
 fluent-logger==0.9.6
 python-json-logger==0.1.11


### PR DESCRIPTION
(cherry picked from commit 9e084b35ea14ae836985e45a502438f5e0b0f830)