### PR TITLE
build: replaces edx-proctoring fork with a compatible opendx release

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -3,5 +3,5 @@
 -e git+https://github.com/eol-uchile/eol_sso_login@0.1.1#egg=eol_sso_login
 -e git+https://github.com/eol-uchile/eol_survey@1.0.0#egg=eol_survey
 -e git+https://github.com/eol-uchile/eol_vimeo@1.0.0#egg=eol_vimeo
--e git+https://github.com/open-uchile/edx-proctoring@3815d8852fc7059848444fbe401a5c08f89a9aac#egg=edx-proctoring
+-e git+https://github.com/openedx/edx-proctoring@2.6.7#egg=edx-proctoring
 -e git+https://github.com/eol-uchile/eol_contact_form@0.2.2+open#egg=eol_contact_form


### PR DESCRIPTION
Se reemplaza el fork de open edx-proctoring en openuchile por un release de openedx compatible con koa.