### PR TITLE
build: updates eol-zoom to v1.1.2

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -16,7 +16,7 @@
 -e git+https://github.com/eol-uchile/eol-question-xblock@v1.0.0#egg=eolquestion-xblock
 -e git+https://github.com/eol-uchile/eol-vof-xblock@v1.0.1#egg=vof-xblock
 -e git+https://github.com/eol-uchile/eol_xblock_discussion@1.0.0#egg=eoldiscussion-xblock
--e git+https://github.com/eol-uchile/eol-zoom-xblock@1.1.1#egg=eolzoom-xblock
+-e git+https://github.com/eol-uchile/eol-zoom-xblock@1.1.2#egg=eolzoom-xblock
 -e git+https://github.com/eol-uchile/flow-control-xblock@v1.0.1#egg=flow-control-xblock
 -e git+https://github.com/eol-uchile/free-text-response@0.4.0#egg=xblock-free-text-response
 -e git+https://github.com/eol-uchile/pdfXBlock@v0.5.1#egg=pdf-xblock


### PR DESCRIPTION
Se hace un upgrade de eol-zoom a la version 1.1.2, la cual instala la version v0.22.0 de httplib2 para evitar problemas al hacer build de la imagen.
Ademas se cambia la version de XBlock a <2.