### PR TITLE
build: adds a compatible openedx edx-proctoring release

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,3 +1,4 @@
+-e git+https://github.com/openedx/edx-proctoring@2.6.7#egg=edx-proctoring
 -e git+https://github.com/eol-uchile/edx-ucursos@1.0.0#egg=edxucursos
 -e git+https://github.com/eol-uchile/edx-userdata@1.0.0#egg=edxuserdata
 -e git+https://github.com/eol-uchile/eol_contact_form@0.0.1#egg=eol_contact_form


### PR DESCRIPTION
Se instala un release de edx-proctoring de openedx compatible con koa.
En eol-edx esta instalado el fork de eol de edx-proctoring, y la idea de este pr es poder probar en staging como se comporta un release de openedx de edx-proctoring(misma version ya instalada en openuchile), para asi dejar de ocupar el fork de eol.