### PR TITLE
build: remove unused dependency entries to match production

### DIFF
--- a/requirements/apis.txt
+++ b/requirements/apis.txt
@@ -1,2 +1,1 @@
 -e git+https://github.com/eol-uchile/CMM-API@03c52a7087341288f01aa3fe130c6d3f0e34cade#egg=cmmapi
--e git+https://github.com/eol-uchile/portal_api@0.3#egg=portal_api

--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -7,5 +7,4 @@
 -e git+https://github.com/eol-uchile/eol_jump_to@0.0.1#egg=eol_jump_to
 -e git+https://github.com/eol-uchile/eol_survey@1.0.0#egg=eol_survey
 -e git+https://github.com/eol-uchile/eol_vimeo@1.0.0#egg=eol_vimeo
--e git+https://github.com/eol-uchile/super-csv@7eba102f1ce365131d05ba60967ada7b04a194d1#egg=super_csv
 -e git+https://github.com/eol-uchile/uchileedxlogin@1.0.0#egg=uchileedxlogin


### PR DESCRIPTION
Removed `super-csv` and `portal-api` from staging since those are not being used in https://github.com/eol-uchile/eol-edx