### PR TITLE
build: add tag 1.0.0 to eol-gradeforum-xblock to eol

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -9,7 +9,7 @@
 -e git+https://github.com/eol-uchile/eol-dialogs-question-xblock@v1.0.0#egg=dialogsquestionsxblock-xblock
 -e git+https://github.com/eol-uchile/eol-dialogs-xblock@d7386ecf32511ce720173276736a11cc3a1301c5#egg=eoldialogs-xblock
 -e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.0#egg=eol_forum_notifications
--e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1b5160b01a081aa68b42f9aed87845fa88b2b8a0#egg=eolgradediscussion
+-e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1.0.0#egg=eolgradediscussion
 -e git+https://github.com/eol-uchile/eol_img_annotation@1.0.0#egg=img-annotation
 -e git+https://github.com/eol-uchile/eol_list_grade@1.0.0#egg=eollistgrade-xblock
 -e git+https://github.com/eol-uchile/eol-persistent-tab-xblock@1.0.0#egg=eolpersistenttab-xblock


### PR DESCRIPTION
Se añadió la generación del badge de cobertura en test.sh y se incorporó el archivo setup.cfg. Se sumaron varias pruebas para aumentar la cobertura y se refactorizó el código eliminando importaciones innecesarias, así como las funciones no utilizadas is_instructor y max_score. Además, se actualizaron las instrucciones para ejecutar los tests y se añadió el badge de cobertura en la documentación. Finalmente, se actualizó la configuración del setup para incluir versión semántica e información de metadatos.

También se agrego el tag 1.0.0