### PR TITLE
build: change repository from eol to eduNEXT

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -17,7 +17,7 @@
 -e git+https://github.com/eol-uchile/eol-vof-xblock@v1.0.1#egg=vof-xblock
 -e git+https://github.com/eol-uchile/eol_xblock_discussion@1.0.0#egg=eoldiscussion-xblock
 -e git+https://github.com/eol-uchile/eol-zoom-xblock@1.1.2#egg=eolzoom-xblock
--e git+https://github.com/eol-uchile/flow-control-xblock@v1.0.1#egg=flow-control-xblock
+-e git+https://github.com/eduNEXT/flow-control-xblock@v1.0.1#egg=flow-control-xblock
 -e git+https://github.com/eol-uchile/free-text-response@0.4.0#egg=xblock-free-text-response
 -e git+https://github.com/eol-uchile/pdfXBlock@v0.5.1#egg=pdf-xblock
 -e git+https://github.com/eol-uchile/sence-xblock@1.0.0#egg=sence-xblock


### PR DESCRIPTION
Se modifica el repositorio de eol a eduNEXT puesto que hacen referencia al mismo commit 