### PR TITLE
build: update open theme and course_classification tag to 1.2.1

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/eol-uchile/course_classification@1.2.0#egg=course_classification
+-e git+https://github.com/eol-uchile/course_classification@1.2.1#egg=course_classification
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock
 -e git+https://github.com/eol-uchile/eol_sso_login@0.1.1#egg=eol_sso_login
 -e git+https://github.com/eol-uchile/eol_survey@1.0.0#egg=eol_survey


### PR DESCRIPTION
Se actualiza el tema  de open para corregir traducciones y se corrige course_classification cuando el curso no tiene visibilidad both para mostrar solo organizaciones  y caracteristicas que si tengan ese tipo de cursos