### PR TITLE
build: update eol_forum_notification tag to 1.0.4

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -8,7 +8,7 @@
 -e git+https://github.com/eol-uchile/eol-course-program-xblock@0.2.0#egg=eolcourseprogram-xblock
 -e git+https://github.com/eol-uchile/eol-dialogs-question-xblock@v1.0.0#egg=dialogsquestionsxblock-xblock
 -e git+https://github.com/eol-uchile/eol-dialogs-xblock@1.0.0#egg=eoldialogs-xblock
--e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.3#egg=eol_forum_notifications
+-e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.4#egg=eol_forum_notifications
 -e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1.0.0#egg=eolgradediscussion
 -e git+https://github.com/eol-uchile/eol_img_annotation@1.0.0#egg=img-annotation
 -e git+https://github.com/eol-uchile/eol_list_grade@1.0.0#egg=eollistgrade-xblock


### PR DESCRIPTION
Se actualiza el tag de eol_forum_notification a 1.0.4 donde se modifica el que el correo de ayuda este en duro a leerlo con una variable propia de platfom