### PR TITLE
build: remove xblock discussion from open theme

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -7,6 +7,6 @@
 -e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.4#egg=eol_forum_notifications
 -e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1.0.0#egg=eolgradediscussion
 -e git+https://github.com/eol-uchile/eol_list_grade@1.0.0#egg=eollistgrade-xblock
--e git+https://github.com/eol-uchile/eol_xblock_discussion@1.0.1#egg=eoldiscussion-xblock
+-e git+https://github.com/eol-uchile/eol_xblock_discussion@1.1.1#egg=eoldiscussion-xblock
 -e git+https://github.com/eol-uchile/pdfXBlock@v0.5.1#egg=pdf-xblock
 -e git+https://github.com/eol-uchile/sence-xblock@2.0.0#egg=sence-xblock


### PR DESCRIPTION
- update xblock-discussion tag to 1.1.1
- remove xblock-discussion from open theme and update tag to 1.2.0

Respecto a eol-xblock-discussion:

- Se agregan diferentes cambios de ci respecto a wk, eliminar test.sh, entre otros.
- Se modifica como se leer las templates estáticas desde mako
- Se actualiza el contenido de las templates a las que se encontraban en eol-theme
- Se agrega el test modificado
- Se modifican las instrucciones

Respecto a open:
- Se corrige el error para mostrar una fila por cada 2 cursos, y no 4 cursos por fila
- Se quita un espacio en el login para que la imagen del separador no tenga ese espacio en blanco
- Se corrige el schema org
- Se agregan los valores iniciales, colores básicos y máximo ancho
- Se agrega una clase para el máximo ancho de los elementos
- Se eliminan las plantillas relacionadas a eol-xblock-discussion dado que ahora estas se renderizan dentro del mismo xblock