### PR TITLE
chore: add requirements/apps/ and requirements/extensions/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 env/
 venv/
+requirements/apps/
+requirements/extensions/


### PR DESCRIPTION
When we are developing an app or xblock in this repository, we typically work in `/requirements/apps` or `/requirements/extensions`. However, we do not want the code developed in those paths to be versioned in this repository, but rather in its own dedicated repository.