### PR TITLE
build: update course_classification tag to 1.5.2

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/eol-uchile/course_classification@1.5.0#egg=course_classification
+-e git+https://github.com/eol-uchile/course_classification@1.5.2#egg=course_classification
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock
 -e git+https://github.com/eol-uchile/eol_sso@1.0.1#egg=eol_sso


### PR DESCRIPTION
Se actualiza el tag de course_classification donde se agrega el comando de migración y un test para la función get_all_categories_and_its_courses