### PR TITLE
build: update eol-api tag to 1.2.0

### DIFF
--- a/requirements/apis.txt
+++ b/requirements/apis.txt
@@ -1,2 +1,2 @@
 -e git+https://github.com/eol-uchile/CMM-API@03c52a7087341288f01aa3fe130c6d3f0e34cade#egg=cmmapi
--e git+https://github.com/eol-uchile/eol-api@1.1.0#egg=eol_api
+-e git+https://github.com/eol-uchile/eol-api@1.2.0#egg=eol_api


### PR DESCRIPTION
Se agrega el que se puede ver el historial de clientCourses en el administrador de django
Se actualiza el tag de eol-api a 1.2.0