### PR TITLE
build: update different  xblock tag to eol

### DIFF
--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/eol-uchile/eol_completion@2.0.0#egg=eol_completion
 -e git+https://github.com/eol-uchile/eol_course_email@0.0.1#egg=eol_course_email
--e git+https://github.com/eol-uchile/eol_feedback@8fb78e4a9acfe2d1d3e48c296721029ec9b7cdf1#egg=eol_feedback
+-e git+https://github.com/eol-uchile/eol_feedback@0.0.3#egg=eol_feedback
 -e git+https://github.com/eol-uchile/eol_progress_tab@0.0.1#egg=eol_progress_tab
 -e git+https://github.com/eol-uchile/eol_welcome_mail@0.0.1#egg=welcome_mail

--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -9,9 +9,9 @@
 -e git+https://github.com/eol-uchile/eol-course-program-xblock@df549273a21c6b4674c6645940d7f33c4c8a2aea#egg=eolcourseprogram-xblock
 -e git+https://github.com/eol-uchile/eol-dialogs-question-xblock@v1.0.0#egg=dialogsquestionsxblock-xblock
 -e git+https://github.com/eol-uchile/eol-dialogs-xblock@1.0.0#egg=eoldialogs-xblock
--e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.3#egg=eol_forum_notifications
+-e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.4#egg=eol_forum_notifications
 -e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1.0.0#egg=eolgradediscussion
--e git+https://github.com/eol-uchile/eol_img_annotation@1.0.0#egg=img-annotation
+-e git+https://github.com/eol-uchile/eol_img_annotation@1.0.1#egg=img-annotation
 -e git+https://github.com/eol-uchile/eol_list_grade@1.0.0#egg=eollistgrade-xblock
 -e git+https://github.com/eol-uchile/eol-persistent-tab-xblock@1.0.0#egg=eolpersistenttab-xblock
 -e git+https://github.com/eol-uchile/eol-question-xblock@v1.0.0#egg=eolquestion-xblock
@@ -19,7 +19,7 @@
 -e git+https://github.com/eol-uchile/eol_xblock_discussion@1.1.1#egg=eoldiscussion-xblock
 -e git+https://github.com/eol-uchile/eol-zoom-xblock@1.1.2#egg=eolzoom-xblock
 -e git+https://github.com/eduNEXT/flow-control-xblock@v1.0.1#egg=flow-control-xblock
--e git+https://github.com/eol-uchile/free-text-response@0.4.0#egg=xblock-free-text-response
+-e git+https://github.com/eol-uchile/free-text-response@0.4.1#egg=xblock-free-text-response
 -e git+https://github.com/eol-uchile/pdfXBlock@v0.5.1#egg=pdf-xblock
 -e git+https://github.com/eol-uchile/sence-xblock@2.0.0#egg=sence-xblock
 -e git+https://github.com/eol-uchile/ubcpi@1.0.0#egg=ubcpi-xblock


### PR DESCRIPTION
Se actualizan los tags de 
- eol_forum_notifications a  1.0.4 -->  se agrega variable para leer el mail, desde una variable del plattform y no en duro en el código 
- eol_img_annotation a 1.0.1 --> temas de ci, se elimino una función que no se usaba y se agregaron test para aumentar el coverage
- free-text-response a 0.4.1 --> temas de cm, eliminaciónn de test sh
- eol_feedback a 0.0.3 --> correcciones para lilac, y cambios de ci