### PR TITLE
build: update eol_sso and related apps tag and open-uchile-theme

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,8 +1,8 @@
 -e git+https://github.com/eol-uchile/course_classification@1.5.2#egg=course_classification
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock
--e git+https://github.com/eol-uchile/eol_sso@1.0.1#egg=eol_sso
+-e git+https://github.com/eol-uchile/eol_sso@1.2.0#egg=eol_sso
 -e git+https://github.com/eol-uchile/eol_sso_login@0.1.1#egg=eol_sso_login
--e git+https://github.com/eol-uchile/eol_survey@1.0.0#egg=eol_survey
+-e git+https://github.com/eol-uchile/eol_survey@3.1.0#egg=eol_survey
 -e git+https://github.com/eol-uchile/eol_vimeo@1.0.1#egg=eol_vimeo
 -e git+https://github.com/openedx/edx-proctoring@2.6.7#egg=edx-proctoring

--- a/requirements/reports.txt
+++ b/requirements/reports.txt
@@ -1,1 +1,3 @@
--e git+https://github.com/eol-uchile/eol_report_analytics@0.0.1#egg=eol_report_analytics
+-e git+https://github.com/eol-uchile/eol_report_analytics@2.1.0#egg=eol_report_analytics
+-e git+https://github.com/eol-uchile/eol_report_certificate@2.1.1#egg=eolreportcertificate
+-e git+https://github.com/eol-uchile/eol_xblock_completion@1.1.0#egg=xblockcompletion

--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/eol-uchile/eol_completion@0.0.1+open#egg=eol_completion
+-e git+https://github.com/eol-uchile/eol_completion@2.0.0#egg=eol_completion
 -e git+https://github.com/eol-uchile/eol_course_email@cfcca8a18389f64a1383f686a684c585019d16f1#egg=eol_course_email
 -e git+https://github.com/eol-uchile/eol_progress_tab@698177942488d4bc3c3b931887e6fef0b94473aa#egg=eol_progress_tab
 -e git+https://github.com/eol-uchile/eol_welcome_mail@0.0.1#egg=welcome-mail


### PR DESCRIPTION
Se actualiza la version de eol_sso, la cual incluye el modelo UserSso.
Se actualizan las versiones de eol_survey, eol_report_analytics y eol_completion, para que consulten el indiv_id directamente desde eol_sso en vez de eol_sso_login.
Se agregan los reportes eol_report_certificate y eol_xblock_completion, ya que son compatibles con la version incluida de eol_sso.
Se actualiza la version de open-uchile-theme para que importe los templates de las interfaces de los reportes en vez de tener el codigo de estas en el tema.