### PR TITLE
build: remove super-csv from python_packages

### DIFF
--- a/requirements/python_packages.txt
+++ b/requirements/python_packages.txt
@@ -2,4 +2,3 @@ django-redis==4.12.1
 -e git+https://github.com/mitodl/edx-username-changer.git@main#egg=edx-username-changer
 fluent-logger==0.9.6
 python-json-logger==0.1.11
-super-csv==3.2.0


### PR DESCRIPTION
Removes `super-csv` from python_packages because platform base already have it.

This reverts commit 6c18efb59cd68d1ea1ebd06fa1d1f1b0612ac2f7.