### PR TITLE
build: update eol_sso_login tag to 0.1.2

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -2,7 +2,7 @@
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock
 -e git+https://github.com/eol-uchile/eol_sso@1.2.0#egg=eol_sso
--e git+https://github.com/eol-uchile/eol_sso_login@0.1.1#egg=eol_sso_login
+-e git+https://github.com/eol-uchile/eol_sso_login@0.1.2#egg=eol_sso_login
 -e git+https://github.com/eol-uchile/eol_survey@3.1.0#egg=eol_survey
 -e git+https://github.com/eol-uchile/eol_vimeo@1.0.1#egg=eol_vimeo
 -e git+https://github.com/openedx/edx-proctoring@2.6.7#egg=edx-proctoring


### PR DESCRIPTION
Se corrige le enlace roto y se modifican las instrucciones donde se mencionaban dichos links para mantener concordante las cosas y se actualiza la version a 0.1.2