### PR TITLE
build: replace eol-report-certificate

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,6 +1,6 @@
 -e git+https://github.com/eol-uchile/course_classification@1.5.2#egg=course_classification
 -e git+https://github.com/eol-uchile/edx-ucursos@2.0.0#egg=edxucursos
--e git+https://github.com/eol-uchile/eol-certificates@0.1.0#egg=eol_certificates
+-e git+https://github.com/eol-uchile/eol-certificates@0.2.0#egg=eol_certificates
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock
 -e git+https://github.com/eol-uchile/eol_jump_to@0.0.1#egg=eol_jump_to

--- a/requirements/reports.txt
+++ b/requirements/reports.txt
@@ -1,5 +1,4 @@
 -e git+https://github.com/cmmedu/cmmedu-seguimiento@v1.2.1#egg=cmmedu_seguimiento
 -e git+https://github.com/eol-uchile/eol_grade_ucursos@3.0.0#egg=gradeucursos
 -e git+https://github.com/eol-uchile/eol_report_analytics@2.1.0#egg=eol_report_analytics
--e git+https://github.com/eol-uchile/eol_report_certificate@2.1.1#egg=eolreportcertificate
 -e git+https://github.com/eol-uchile/eol_xblock_completion@1.1.0#egg=xblockcompletion


### PR DESCRIPTION
- Se elimina eol-report-certificates
- Se actualiza el tag eol-certificates a 0.2.0 donde se hizo el traspaso de funciones eol-report-certificates
- Se actualiza eol-theme para modificar el url con la nueva dependencia