### PR TITLE
build: update course_classification tag to 1.6.0

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/eol-uchile/course_classification@1.5.2#egg=course_classification
+-e git+https://github.com/eol-uchile/course_classification@1.6.0#egg=course_classification
 -e git+https://github.com/eol-uchile/eol-certificates@0.2.0#egg=eol_certificates
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock


### PR DESCRIPTION
- Se actualiza el tag de curse_classification a 1.6.0 
- Se agregan settings nuevas para el año de inicio y tiempo en el futuro para el calculo de años
- Se agrega un nuevo endpoint para obtener los valores iniciales del año inicial y el tiempo extra para utilizarlas en el front