### PR TITLE
build(eol): update edx-ucursos to 3.0.1

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/eol-uchile/course_classification@1.6.0#egg=course_classification
--e git+https://github.com/eol-uchile/edx-ucursos@3.0.0#egg=edxucursos
+-e git+https://github.com/eol-uchile/edx-ucursos@3.0.1#egg=edxucursos
 -e git+https://github.com/eol-uchile/eol-certificates@0.2.0#egg=eol_certificates
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0#egg=eol_duplicate_xblock


### PR DESCRIPTION
La vista de edx-ucursos ahora retorna una respuesta 200 OK con la URL en texto plano en lugar de un 302.
El parámetro 'next' ahora se codifica mediante urlquote_plus en lugar de base64.
Se actualizan los tests.