### PR TITLE
build(eol): update eol_completion version to 2.1.0+dev

### DIFF
--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/eol-uchile/eol_completion@2.0.1#egg=eol_completion
+-e git+https://github.com/eol-uchile/eol_completion@2.1.0+dev#egg=eol_completion
 -e git+https://github.com/eol-uchile/eol_course_email@0.0.1#egg=eol_course_email
 -e git+https://github.com/eol-uchile/eol_feedback@0.0.3#egg=eol_feedback
 -e git+https://github.com/eol-uchile/eol_progress_tab@0.0.1#egg=eol_progress_tab


### PR DESCRIPTION
Agregar endpoints nuevos con `get_ticks_fast` para comparar vs actual. Incluye compresión de cache y timing en Celery.

La idea es comparar el rendimiento de los dos endpoints en un escenario similar en el cluster para medir la mejora en performance.

Una vez validada la mejora, se reemplazaran las vistas en el repo original.