### PR TITLE
build: rm eol_course_email & eol_progress_tab

### DIFF
--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,4 +1,2 @@
 -e git+https://github.com/eol-uchile/eol_completion@2.0.1#egg=eol_completion
--e git+https://github.com/eol-uchile/eol_course_email@0.0.1#egg=eol_course_email
--e git+https://github.com/eol-uchile/eol_progress_tab@0.0.1#egg=eol_progress_tab
 -e git+https://github.com/eol-uchile/eol_welcome_mail@0.0.1#egg=welcome-mail


### PR DESCRIPTION
Se eliminan eol_course_email y eol_progress_tab, eol_progress_tab si bien funciona se considero que lo que aporta no es tan relevante, por otro lado eol_course_email no sirve al instalarla.