### PR TITLE
build(EOL): update eol_vimeo to fix how to obtain course_id

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -6,6 +6,6 @@
 -e git+https://github.com/eol-uchile/eol_jump_to@0.0.1#egg=eol_jump_to
 -e git+https://github.com/eol-uchile/eol_sso@1.3.1#egg=eol_sso
 -e git+https://github.com/eol-uchile/eol_survey@3.2.0#egg=eol_survey
--e git+https://github.com/eol-uchile/eol_vimeo@2.0.0+dev#egg=eol_vimeo
+-e git+https://github.com/eol-uchile/eol_vimeo@2.0.0+dev2#egg=eol_vimeo
 -e git+https://github.com/eol-uchile/uchileedxlogin@2.0.1#egg=uchileedxlogin
 -e git+https://github.com/openedx/edx-proctoring@2.6.7#egg=edx-proctoring


### PR DESCRIPTION
En eol_vimeo se actualiza el tag con el fix que corrige como se obtiene el el course_id