### PR TITLE
build: update tag eol_vimeo to 2.0.0+dev4

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -6,6 +6,6 @@
 -e git+https://github.com/eol-uchile/eol_jump_to@0.0.1#egg=eol_jump_to
 -e git+https://github.com/eol-uchile/eol_sso@1.4.0-dev#egg=eol_sso
 -e git+https://github.com/eol-uchile/eol_survey@3.2.0#egg=eol_survey
--e git+https://github.com/eol-uchile/eol_vimeo@2.0.0+dev2#egg=eol_vimeo
+-e git+https://github.com/eol-uchile/eol_vimeo@2.0.0+dev4#egg=eol_vimeo
 -e git+https://github.com/eol-uchile/uchileedxlogin@2.0.1#egg=uchileedxlogin
 -e git+https://github.com/openedx/edx-proctoring@2.6.7#egg=edx-proctoring


### PR DESCRIPTION
Se actualiza eol_vimeo para corregir el error de course_id con un nuevo método
Se agregan traducciones a eol_vimeo agregando nuevas frases en desde el nuevo archivo .js