### PR TITLE
Build(OPEN): add  eol_jump_to in 0.0.1+l version

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -2,6 +2,7 @@
 -e git+https://github.com/eol-uchile/eol-certificates@0.2.0+l#egg=eol_certificates
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3+l#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0+l#egg=eol_duplicate_xblock
+-e git+https://github.com/eol-uchile/eol_jump_to@0.0.1+l#egg=eol_jump_to
 -e git+https://github.com/eol-uchile/eol_sso@1.2.0#egg=eol_sso
 -e git+https://github.com/eol-uchile/eol_sso_login@0.1.2+l#egg=eol_sso_login
 -e git+https://github.com/eol-uchile/eol_survey@3.2.1+l#egg=eol_survey


### PR DESCRIPTION
Se agrega eol_jump_to para corregir el error de cuando una persona esta en la lista de sus cursos, en un cursos en especifico en el botón continuar con el curso y el profesor (o en cargado del curso) borra el ultimo elemento te lleva a una pagina de error 404, eol_jump_to te redirige al indice del curso