### PR TITLE
build(OPEN): update eol_completion tag to 2.1.1+l

### DIFF
--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/eol-uchile/eol_completion@2.1.0+l#egg=eol_completion
+-e git+https://github.com/eol-uchile/eol_completion@2.1.1+l#egg=eol_completion
 -e git+https://github.com/eol-uchile/eol_welcome_mail@0.0.1+l#egg=welcome-mail


### PR DESCRIPTION
This new version of eol_completion fixes a bug introduced in https://github.com/eol-uchile/eol_completion/pull/27 where the signal handlers ran for every task, so unrelated tasks emitted logs as if they came from this app. The logs are removed until future implementation after https://github.com/eol-uchile/eol_completion/issues/31.