### PR TITLE
build(LILAC): update tags & rm unused xblocks

### DIFF
--- a/requirements/apps.txt
+++ b/requirements/apps.txt
@@ -1,10 +1,9 @@
--e git+https://github.com/eol-uchile/course_classification@1.6.0#egg=course_classification
+-e git+https://github.com/eol-uchile/course_classification@1.6.1+l#egg=course_classification
 -e git+https://github.com/eol-uchile/edx-ucursos@3.1.0+l#egg=edxucursos
 -e git+https://github.com/eol-uchile/eol-certificates@0.2.0+l#egg=eol_certificates
 -e git+https://github.com/eol-uchile/eol_contact_form@0.5.3+l#egg=eol_contact_form
 -e git+https://github.com/eol-uchile/eol_duplicate_xblock@1.0.0+l#egg=eol_duplicate_xblock
--e git+https://github.com/eol-uchile/eol_jump_to@0.0.1#egg=eol_jump_to
 -e git+https://github.com/eol-uchile/eol_sso@1.4.1-dev5#egg=eol_sso
 -e git+https://github.com/eol-uchile/eol_survey@3.2.1+l#egg=eol_survey
 -e git+https://github.com/eol-uchile/eol_vimeo@2.0.0+dev5#egg=eol_vimeo
--e git+https://github.com/eol-uchile/uchileedxlogin@2.0.1#egg=uchileedxlogin
+-e git+https://github.com/eol-uchile/uchileedxlogin@2.0.2+l#egg=uchileedxlogin

--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/eol-uchile/eol_completion@2.1.0+dev#egg=eol_completion
+-e git+https://github.com/eol-uchile/eol_completion@2.1.1+l#egg=eol_completion
 -e git+https://github.com/eol-uchile/eol_course_email@0.0.1+l#egg=eol_course_email
 -e git+https://github.com/eol-uchile/eol_feedback@0.0.3+l#egg=eol_feedback
 -e git+https://github.com/eol-uchile/eol_progress_tab@0.0.1+l#egg=eol_progress_tab

--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -2,11 +2,11 @@
 -e git+https://github.com/cmmedu/cmmedu-ordertable-xblock@v1.0.1#egg=cmmedu-ordertable-xblock
 -e git+https://github.com/eol-uchile/edx-ora2@e873498bd2671b830f19a2441ec1608b7d4bbbc4#egg=ora2
 -e git+https://github.com/eol-uchile/edx-sga@0.10.0+eol3.1.2#egg=edx-sga
-# -e git+https://github.com/eol-uchile/edx_xblock_scorm@c23184c0e22a7847f0b0c917bbe431c2973770fb#egg=scormxblock-xblock
+-e git+https://github.com/eol-uchile/edx_xblock_scorm@0.5.1+l#egg=scormxblock-xblock
 -e git+https://github.com/eol-uchile/eol-conditional-xblock@1.0.0+l#egg=eolconditional-xblock
--e git+https://github.com/eol-uchile/eol-container-xblock@v1.1.0#egg=eolcontainer-xblock
+-e git+https://github.com/eol-uchile/eol-container-xblock@v1.2.0+l#egg=eolcontainer-xblock
 -e git+https://github.com/eol-uchile/eol-course-program-xblock@0.2.0+l#egg=eolcourseprogram-xblock
--e git+https://github.com/eol-uchile/eol-dialogs-question-xblock@v1.0.0#egg=dialogsquestionsxblock-xblock
+-e git+https://github.com/eol-uchile/eol-dialogs-question-xblock@v1.1.0+l#egg=dialogsquestionsxblock-xblock
 -e git+https://github.com/eol-uchile/eol-dialogs-xblock@1.0.0+l#egg=eoldialogs-xblock
 -e git+https://github.com/eol-uchile/eol_forum_notifications@1.0.4+l#egg=eol_forum_notifications
 -e git+https://github.com/eol-uchile/eol_gradeforum_xblock@1.0.0+l#egg=eolgradediscussion
@@ -21,6 +21,5 @@
 -e git+https://github.com/eol-uchile/free-text-response@0.4.1+l#egg=xblock-free-text-response
 -e git+https://github.com/eol-uchile/pdfXBlock@v0.5.1+l#egg=pdf-xblock
 -e git+https://github.com/eol-uchile/sence-xblock@2.0.0+l#egg=sence-xblock
--e git+https://github.com/eol-uchile/ubcpi@1.0.0#egg=ubcpi-xblock
 -e git+https://github.com/openedx/xblock-drag-and-drop-v2@v3.0.0#egg=xblock-drag-and-drop-v2
 -e git+https://github.com/eol-uchile/xblock-in-video-quiz@1.1.0+l#egg=invideoquiz


### PR DESCRIPTION
- Actualiza el tag de eol_completion tag desde 2.1.0+dev a 2.1.1+l
- Actualiza el tag de course_classification tag desde 1.6.0 a 1.6.1+l
- Actualiza el tag de uchileedxlogin tag desde 2.0.1 a 2.0.2+l
- Actualiza el tag de eol-dialogs-question-xblock tag desde 1.0.0 a 1.1.0+l
- Actualiza el tag de eol-container-xblock tag desde 1.1.0 a 1.2.0+l
- Se agrega el tag de edx_xblock_scorm en 0.5.1+l
- Se elimina el xblock eol_jump
- Se elimina el xblock ubcpi
- Se actualiza el tema de eol con los siguientes cambios:
  - Se hacen 2 cambios relacionados con img_annotation:
     -  Se actualiza el import path de las bibliotecas osd y annotorious, ya que fueron cambiadas de ubicacion en el xblock.
     -  Se actualiza la version de OpenseaDragon.
  - Se modifica la función de cálculo de nota para pasar de escala de porcentaje a escala de 1 a 7 en la pestaña progreso. La razón de esta modificación, es que las funciones round operando sobre representaciones decimales de punto flotante, tanto en python como javascript, aproximan utilizando la regla to nearest, ties to even. Esto provoca que la aproximación de notas como 3.95 o 6.85 sea con el comportamiento de cajón inferior, es decir, a 3.9 y 6.8 respectivamente, que es incorrecto matemáticamente.
  - Se actualiza la importación de course_info
  - Se elimina contact_form del tema de eol
  - Se agrega el archivo de versión para orden
  - Se modifica el como traer los cursos al dashboard principal,se elimina el uso de couse_info para reemplazarlos por el uso de course_clasification
  - Se actualiza la imagen png del logo vti pues había una falta ortográfica
  - Se actualiza agrega le logo de openex al footer
  - Se eliminan las plantillas relacionadas a eol-xblock-discussion dado que ahora estas se renderizan dentro del mismo xblock
  - Deja de importar los archivos JS y CSS asociados a las aplicaciones de informes de EOL; en su lugar, impórtalos directamente con la plantilla.
  - Añade comprobaciones para ver si las aplicaciones de informes están instaladas y, solo si lo están, incluye su plantilla.
  - Se importan las templates directamente desde la app y no desde el tema los los siguientes xblock: 
    - eol_report_certificate
      - Se movio a otra sección 
    - xblock_completion
    - eol_report_analytics
    - eol_survey
    - gradeucursos
  -  Se elimina la template de footer del tema para utiliza la de upstream, agregando css para modificar el diseño de la original
  - Se elimna la plantilla de validate_certificates pues esta sera reemplazada por la que se encuentra en la app eol-certificates
  - Se actualiza el link de acuerdo al traspaso de eol-certificates de eol-certificates-report
  - Se agregan las herramientas para traducir dejando los archivos separados por tipo de archivo
  - Se separan los archivos .po
  - Se eliminan templates de email pues están en platform
  - Se actualizan los msgid de español a ingles manteniendo las traducciones
  - Se elimina eol_jump_to