### PR TITLE
build(EOL): rollback ora2 tag to 2.11.6+eol1.0.0

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -1,6 +1,6 @@
 -e git+https://github.com/cmmedu/iterative-xblock@v1.0.5#egg=iterativexblock
 -e git+https://github.com/cmmedu/cmmedu-ordertable-xblock@v1.0.1#egg=cmmedu-ordertable-xblock
--e git+https://github.com/eol-uchile/edx-ora2@2.13.3+eol1.0.0#egg=ora2
+-e git+https://github.com/eol-uchile/edx-ora2@2.11.6+eol1.0.0#egg=ora2
 -e git+https://github.com/eol-uchile/edx-sga@0.10.0+eol3.1.2#egg=edx-sga
 -e git+https://github.com/eol-uchile/edx_xblock_scorm@0.5.1+l#egg=scormxblock-xblock
 -e git+https://github.com/eol-uchile/eol-conditional-xblock@1.0.0+l#egg=eolconditional-xblock


### PR DESCRIPTION
Se actualiza ora2  a la maxima version que no da problemas de compilación para koa