### PR TITLE
build(OPEN): update completion tag to 2.1.2+l

### DIFF
--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/eol-uchile/eol_completion@2.1.1+l#egg=eol_completion
+-e git+https://github.com/eol-uchile/eol_completion@2.1.2+l#egg=eol_completion
 -e git+https://github.com/eol-uchile/eol_welcome_mail@0.0.1+l#egg=welcome-mail


### PR DESCRIPTION
Se actualiza el tag de eol_completion a  2.1.2+l, para agrega invideoquiz a los xblocks que se cuentan en el completion