### PR TITLE
build(LILAC): update completion tag to 2.1.2+l

### DIFF
--- a/requirements/tabs_plugins.txt
+++ b/requirements/tabs_plugins.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/eol-uchile/eol_completion@2.1.1+l#egg=eol_completion
+-e git+https://github.com/eol-uchile/eol_completion@2.1.2+l#egg=eol_completion
 -e git+https://github.com/eol-uchile/eol_course_email@0.0.1+l#egg=eol_course_email
 -e git+https://github.com/eol-uchile/eol_feedback@0.0.3+l#egg=eol_feedback
 -e git+https://github.com/eol-uchile/eol_progress_tab@0.0.1+l#egg=eol_progress_tab


### PR DESCRIPTION
Se actualiza el tag de eol_completion a 2.1.2+l, para agrega invideoquiz a los xblocks que se cuentan en el completion